### PR TITLE
Fix cargo install errors with clap 3 stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.0.0-beta.5"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feff3878564edb93745d58cf63e17b63f24142506e7a20c87a5521ed7bfb1d63"
+checksum = "d17bf219fcd37199b9a29e00ba65dfb8cd5b2688b7297ec14ff829c40ac50ca9"
 dependencies = [
  "atty",
  "bitflags",
@@ -159,14 +159,13 @@ dependencies = [
  "strsim",
  "termcolor",
  "textwrap",
- "unicase",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.0.0-beta.5"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b15c6b4f786ffb6192ffe65a36855bc1fc2444bcd0945ae16748dcd6ed7d0d3"
+checksum = "e1b9752c030a14235a0bd5ef3ad60a1dcac8468c30921327fc8af36b20c790b9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -939,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "4.2.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addaa943333a514159c80c97ff4a93306530d965d27e139188283cd13e06a799"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 toml = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
-clap = "3.0.0-beta.5"
+clap = { version = "3.0.0", features = ["derive", "cargo"] }
 dirs = "3.0"
 simple-error = "0.2"
 regex = "1"

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use eso_addons::{
     addons,
     addons::Manager,
@@ -15,7 +16,7 @@ pub struct AddCommand {
     #[clap(
         short,
         long,
-        about = "Indicate, if the addon is only a dependency for another addon"
+        help = "Indicate, if the addon is only a dependency for another addon"
     )]
     #[clap(short)]
     dependency: bool,

--- a/src/cli/clean.rs
+++ b/src/cli/clean.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use colored::*;
 use eso_addons::{
     addons::{Addon, Manager},

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -17,7 +17,7 @@ mod update;
     about = "CLI tool for managing addons for The Elder Scrolls Online"
 )]
 struct Opts {
-    #[clap(short, long, about = "Path to TOML config file")]
+    #[clap(short, long, help = "Path to TOML config file")]
     config: Option<String>,
     #[clap(subcommand)]
     subcmd: SubCommand,


### PR DESCRIPTION
Had issues with cargo install. I also saw clap 3.0.0 was released a couple days ago and there were some breaking changes.