### PR TITLE
Remove set unix files permissions

### DIFF
--- a/src/addons.rs
+++ b/src/addons.rs
@@ -182,16 +182,6 @@ impl Manager {
                 let mut outfile = fs::File::create(&outpath).unwrap();
                 io::copy(&mut file, &mut outfile).unwrap();
             }
-
-            // Get and Set permissions
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-
-                if let Some(mode) = file.unix_mode() {
-                    fs::set_permissions(&outpath, fs::Permissions::from_mode(mode)).unwrap();
-                }
-            }
         }
 
         let mut addon_path = self.addon_dir.to_owned();


### PR DESCRIPTION
Fixes #23 

Using the default permissions, I was able to add and remove the problem addon. The `abilities` directory was created with write permissions:

```shell
LuiExtended/media/icons 
❯ ls -lah
total 148K
drwxr-xr-x 11 arviceblot arviceblot 4.0K Jan  7 15:31 .
drwxr-xr-x  6 arviceblot arviceblot 4.0K Jan  7 15:31 ..
drwxr-xr-x  2 arviceblot arviceblot 104K Jan  7 15:31 abilities
```
