### PR TITLE
Utf8 fix

### DIFF
--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -12,7 +12,14 @@ impl UpdateCommand {
 
         for addon in desired_addons.iter() {
             let installed = if let Some(ref url) = addon.url {
-                let installed = addon_manager.download_addon(&url)?;
+                let installed = match addon_manager.download_addon(&url) {
+                    Ok(installed) => installed,
+                    Err(e) => {
+                        println!("{} Failed {}!", "☒".red(), addon.name);
+                        println!("{}", e.to_string());
+                        continue;
+                    }
+                };
                 Some(installed)
             } else {
                 addon_manager.get_addon(&addon.name)?

--- a/src/htmlparser.rs
+++ b/src/htmlparser.rs
@@ -29,13 +29,13 @@ pub fn get_document(url: &str) -> Result<Html> {
     let mut response = reqwest::blocking::get(url)
         .map_err(|err| Error::CannotDownloadAddon(url.to_owned(), Box::new(err)))?;
 
-    let mut buf = String::new();
+    let mut buf = Vec::new();
 
     response
-        .read_to_string(&mut buf)
+        .read_to_end(&mut buf)
         .map_err(|err| Error::CannotDownloadAddon(url.to_owned(), Box::new(err)))?;
 
-    let document = Html::parse_document(&buf);
+    let document = Html::parse_document(&String::from_utf8_lossy(&buf));
 
     Ok(document)
 }


### PR DESCRIPTION
## Changes

- Allow updating all addons instead of breaking on a single failure
- Fix addon download failure for pages with non UTF-8 characters

Ran in to an issue with a certain addon page containing non UTF-8 characters. This should fix it while not effecting the parsing of the page. I also added a small change that allows updating of remaining addons if one fails to update.

### Example error message:

```shell
> eso-addons update
❌ Failed displayleads!
cannot download addon https://www.esoui.com/downloads/download2651: stream did not contain valid UTF-8
```