### PR TITLE
Add support for addon Metadata files ending with '.addon' extension

### DIFF
--- a/src/addons.rs
+++ b/src/addons.rs
@@ -196,17 +196,22 @@ impl Manager {
     fn open_addon_metadata_file(&self, path: &Path, addon_name: &str) -> Result<File> {
         let mut filepath = path.to_owned();
         let mut filepath_lowercase = path.to_owned();
+        let mut filepath_addon = path.to_owned();
 
         let filename = PathBuf::from(format!("{}.txt", addon_name));
         let filename_lowercase = PathBuf::from(format!("{}.txt", addon_name.to_lowercase()));
+        let filename_addon = PathBuf::from(format!("{}.addon", addon_name));
 
         filepath.push(filename);
         filepath_lowercase.push(filename_lowercase);
+        filepath_addon.push(filename_addon);
 
         if filepath.exists() {
             File::open(&filepath).map_err(|err| Error::Other(Box::new(err)))
         } else if filepath_lowercase.exists() {
             File::open(&filepath_lowercase).map_err(|err| Error::Other(Box::new(err)))
+        } else if filepath_addon.exists() {
+            File::open(&filepath_addon).map_err(|err| Error::Other(Box::new(err)))
         } else {
             Err(Error::Other("missing addon metadata file".into()))
         }


### PR DESCRIPTION
It seems that some mods use files ending with `.addon` extension for their metadata files instead of `.txt`. I don't know anything about mod structures in ESO but this fixed my problem for bunch of Lib mods that didn't have any `.txt` file in them but instead had the `.addon` file.

It may also fix #122 

It's a great tool. Thank you for you work.